### PR TITLE
[WIP] Debugging error

### DIFF
--- a/create-goodbits-template.js
+++ b/create-goodbits-template.js
@@ -154,15 +154,21 @@ async function createTemplate(blogFullContent, browser) {
 	await page.goto(signInPage).then(() => {
 		console.log(`Visiting ${signInPage} ...`);
 	});
-	await page.evaluate((botId, botPwd) => {
-		let emailField = '#user_email';
-		let pwdField = '#user_password';
-		let signInFormSubmit = 'input[type="submit"]';
-		document.querySelector(emailField).setAttribute('value', botId);
-		document.querySelector(pwdField).click();
-		document.querySelector(pwdField).value = botPwd;
-		document.querySelector(signInFormSubmit).click();
-	}, botId, botPwd);
+	console.log(`botId: ${botId}`) // exists
+	console.log(`botPwd: ${botPwd}`) // exists
+	try {
+		await page.evaluate(async (botId, botPwd) => {
+			let emailField = '#user_email';
+			let pwdField = '#user_password';
+			let signInFormSubmit = 'input[type="submit"]';
+			console.log(`email field: ${emailField}`);
+			// how to debug here, can we "run" in any way. from the inspector, seems correct?
+			document.querySelector(emailField).setAttribute('value', botId);
+			document.querySelector(pwdField).click();
+			document.querySelector(pwdField).value = botPwd;
+			document.querySelector(signInFormSubmit).click();
+		}, botId, botPwd);
+	} catch (e) { console.log('in the catch')}
 
 	//wait for main view to load
 	await page.waitForSelector(sidebar).then(() => {


### PR DESCRIPTION
Thought this would make more sense than an issue. First time looking at this code 😳, let me know, feel like I'm missing something

```$ node create-goodbits-template.js --botemail="$GOODBITS_USER_EMAIL" --botpassword="$GOODBITS_USASSWORD" --engine="slimerjs" --botblogurl="https://emberjs.com/blog/2019/02/22/the-ember-times-issue-86.html"
Visiting https://emberjs.com/blog/2019/02/22/the-ember-times-issue-86.html ...
Collected text content from 11 sections to copy.
Visiting https://goodbits.io/users/sign_in ...
(node:20316) UnhandledPromiseRejectionWarning: Error: Evaluation failed: TypeError: Cannot read property 'setAttribute' of null
    at __puppeteer_evaluation_script__:5:37
    at ExecutionContext.evaluateHandle (/Users/amyrlam/src/ember/emberjs-times-tools/node_modules/puppeteer/lib/ExecutionContext.js:124:13)
    at process._tickCallback (internal/process/next_tick.js:68:7)
  -- ASYNC --
    at ExecutionContext.<anonymous> (/Users/amyrlam/src/ember/emberjs-times-tools/node_modules/puppeteer/lib/helper.js:144:27)
    at ExecutionContext.evaluate (/Users/amyrlam/src/ember/emberjs-times-tools/node_modules/puppeteer/lib/ExecutionContext.js:58:31)
    at ExecutionContext.<anonymous> (/Users/amyrlam/src/ember/emberjs-times-tools/node_modules/puppeteer/lib/helper.js:145:23)
    at Frame.evaluate (/Users/amyrlam/src/ember/emberjs-times-tools/node_modules/puppeteer/lib/FrameManager.js:447:20)
    at process._tickCallback (internal/process/next_tick.js:68:7)
  -- ASYNC --
    at Frame.<anonymous> (/Users/amyrlam/src/ember/emberjs-times-tools/node_modules/puppeteer/lib/helper.js:144:27)
    at Page.evaluate (/Users/amyrlam/src/ember/emberjs-times-tools/node_modules/puppeteer/lib/Page.js:777:43)
    at Page.<anonymous> (/Users/amyrlam/src/ember/emberjs-times-tools/node_modules/puppeteer/lib/helper.js:145:23)
    at createTemplate (/Users/amyrlam/src/ember/emberjs-times-tools/create-goodbits-template.js:157:13)
    at process._tickCallback (internal/process/next_tick.js:68:7)
(node:20316) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:20316) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.```